### PR TITLE
Links sqlx-framework badge to sqlx repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **A lightweight sql framework for sustainable database reliant systems**
 
-[![SQLx](https://img.shields.io/badge/sqlx-framework-blueviolet.svg)]()
+[![SQLx](https://img.shields.io/badge/sqlx-framework-blueviolet.svg)](https://github.com/launchbadge/sqlx)
 [![Crate](https://img.shields.io/crates/v/atmosphere.svg)](https://crates.io/crates/atmosphere)
 [![Book](https://img.shields.io/badge/book-latest-0f5225.svg)](https://mara-schulke.github.io/atmosphere)
 [![Docs](https://img.shields.io/badge/docs-latest-153f66.svg)](https://docs.rs/atmosphere)


### PR DESCRIPTION
I noticed that the `sqlx-framework` badge did not have a target. This causes GitHub to interpret it as a link to the current repository. I am assuming that the intention is to link to `sqlx`, so I've added that link.