### PR TITLE
Fixes references to the repository location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 edition = "2021"
 authors = ["Mara Schulke <mara@hemisphere.studio>"]
 description = "A lightweight sql framework for sustainable database reliant systems"
-repository = "https://github.com/hemisphere-studio/atmosphere"
+repository = "https://github.com/mara-schulke/atmosphere"
 keywords = ["sqlx", "postgres", "database", "orm", "backend"]
 
 [workspace.dependencies]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,4 +8,4 @@ underlying sqlx concepts.
 
 **[Getting Started](getting-started/index.md)**
 
-[GitHub]: https://github.com/hemisphere-studio/atmosphere/tree/main
+[GitHub]: https://github.com/mara-schulke/atmosphere/tree/main


### PR DESCRIPTION
It appears like the repository has migrated from it's previous location. To prevent confusion, I have updated the links to the repository in both the Cargo manifest and the documentation.

```mermaid
graph LR
    hemisphere[hemisphere-studios/atmosphere]
    personal[mara-schulke/atmosphere]
    hemisphere --> personal
```