### PR TITLE
Derives miette's Diagnostic for atmosphere errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ trait.
 - [x] Transaction Support
 - [x] Getting Database Agnostic
 - [x] Hook into query execution using `atmosphere::hooks`
-- [ ] Errors using `miette`
+- [x] Errors using `miette`
 - [ ] Combined Primary and Foreign Keys
 
 ### Stable Release

--- a/atmosphere-core/Cargo.toml
+++ b/atmosphere-core/Cargo.toml
@@ -21,3 +21,4 @@ async-trait.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 lazy_static.workspace = true
+miette = "5.10.0"

--- a/atmosphere-core/src/bind.rs
+++ b/atmosphere-core/src/bind.rs
@@ -21,6 +21,7 @@
 //! missing values.
 
 use crate::{Column, Result, Table};
+use miette::Diagnostic;
 use sqlx::database::HasArguments;
 use sqlx::query::QueryAs;
 use sqlx::{Encode, QueryBuilder, Type};
@@ -30,11 +31,12 @@ use thiserror::Error;
 ///
 /// This enum covers various issues that might arise when binding parameters, such as referencing
 /// unknown columns.
-#[derive(Debug, Error)]
+#[derive(Debug, Diagnostic, Error)]
 #[non_exhaustive]
 pub enum BindError {
     /// Represents an error where a specified column is unknown or not found.
     #[error("unknown column: {0}")]
+    #[diagnostic(code(atmosphere::bind::unknown))]
     Unknown(&'static str),
 }
 

--- a/atmosphere-core/src/error.rs
+++ b/atmosphere-core/src/error.rs
@@ -9,6 +9,7 @@
 //! maintainability, especially in scenarios involving complex database interactions and
 //! operations.
 
+use miette::Diagnostic;
 use thiserror::Error;
 
 use crate::{query::QueryError, BindError};
@@ -18,22 +19,27 @@ use crate::{query::QueryError, BindError};
 /// This enum encapsulates a range of errors including IO errors, query-related errors, binding
 /// errors, and others. It is designed to provide a unified error handling mechanism across
 /// different components of the framework.
-#[derive(Debug, Error)]
+#[derive(Debug, Diagnostic, Error)]
 #[non_exhaustive]
 pub enum Error {
     #[error("io")]
+    #[diagnostic(code(atmosphere::io))]
     Io(#[from] std::io::Error),
 
     #[error("query")]
+    #[diagnostic(transparent)]
     Query(#[from] QueryError),
 
     #[error("bind")]
+    #[diagnostic(transparent)]
     Bind(#[from] BindError),
 
     #[error("other")]
+    #[diagnostic(code(atmosphere::other))]
     Other,
 
     #[error("internal")]
+    #[diagnostic(code(atmosphere::internal))]
     Internal,
 }
 


### PR DESCRIPTION
Miette's `Diagnostic` trait allows for adding extra metadata to errors. This [implements](https://docs.rs/miette/latest/miette/#-in-libraries) this trait for the errors defined in `atmosphere-core`.

Some data here might need to be revised, including the error codes specified.