### PR TITLE
Updates book with expanded getting-started guide and traits

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Setup mdbook
         uses: peaceiris/actions-mdbook@v1.2.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install mdbook-keeper --locked || true
       - run: cd docs && mdbook build
       - name: Upload artifacts
         uses: actions/upload-pages-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 docs/book
+docs/doctest_cache

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,9 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Atmosphere"
+
+# comment this out if you do not want to unit-test code examples
+[preprocessor.keeper]
+command = "mdbook-keeper"
+manifest_dir = ".."
+

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,3 +4,10 @@
 
 * [Getting Started](getting-started/index.md)
     * [Installation](getting-started/installation.md)
+    * [Schema](getting-started/schema.md)
+    * [Queries](getting-started/queries.md)
+* [Traits](traits/index.md)
+    * [Create](traits/create.md)
+    * [Read](traits/read.md)
+    * [Update](traits/update.md)
+    * [Delete](traits/delete.md)

--- a/docs/src/getting-started/crud.md
+++ b/docs/src/getting-started/crud.md
@@ -1,0 +1,1 @@
+# Use CRUD traits

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -1,5 +1,8 @@
 ## Getting Started
 
-To get started with atmosphere, install it and set up your first package.
+To get started with atmosphere, install it and set up your first package. Next,
+you will want to define your schema.
 
 * [Installation](installation.md)
+* [Schema](schema.md)
+* [Queries](queries.md)

--- a/docs/src/getting-started/queries.md
+++ b/docs/src/getting-started/queries.md
@@ -1,0 +1,98 @@
+# Queries
+
+When using Atmosphere, you have two options for writing queries. Once you
+derive `Schema` on your entities, it gives you the ability to use querying
+traits that Atmosphere comes with. However, you can at any point reach down
+and write your queries in raw SQL, the way you would if you used `sqlx`
+directly.
+
+## Using Atmosphere Traits
+
+Given the Schema from the section before, here is some examples that show how
+Atmosphere creates traits that allow for simple operations on the tables.
+
+```rust
+# extern crate atmosphere;
+# extern crate sqlx;
+# extern crate tokio;
+# use atmosphere::prelude::*;
+# #[derive(Schema, Debug, PartialEq)]
+# #[table(schema = "public", name = "user")]
+# struct User {
+#     #[sql(pk)]
+#     id: i32,
+#     name: String,
+#     #[sql(unique)]
+#     email: String,
+# }
+# #[derive(Schema, Debug, PartialEq)]
+# #[table(schema = "public", name = "post")]
+# struct Post {
+#     #[sql(pk)]
+#     id: i32,
+#     #[sql(fk -> User, rename = "author_id")]
+#     author: i32,
+#     #[sql(unique)]
+#     title: String,
+# }
+# async fn test() -> std::result::Result<(), Box<dyn std::error::Error>> {
+let database = std::env::var("DATABASE_URL").unwrap();
+let pool = atmosphere::Pool::connect(&database).await?;
+
+let mut user = User {
+    id: 0,
+    name: "demo".to_owned(),
+    email: "some@email.com".to_owned(),
+};
+
+user.save(&pool).await?;
+user.delete(&pool).await?;
+user.create(&pool).await?;
+
+assert_eq!(
+    User::find(&0, &pool).await?,
+    User::find_by_email(&"some@email.com".to_string(), &pool).await?
+);
+
+let mut post = Post {
+    id: 0,
+    author: 0,
+    title: "test".to_owned()
+};
+
+post.save(&pool).await?;
+
+Post::find_by_author(&0, &pool).await?;
+
+// Inter-Table Operations
+
+Post { id: 1, author: 0, title: "test1".to_owned() }
+    .author(&pool).await?;
+
+user.posts(&pool).await?;
+user.delete_posts(&pool).await?;
+# Ok(())
+# }
+# fn main() {}
+```
+
+## Using raw SQL
+
+As previously explained, it is always possible to reach down and perform raw SQL
+queries on an Atmosphere pool, since it is just an alias for an `sqlx` one.
+
+```rust
+# extern crate atmosphere;
+# extern crate sqlx;
+# extern crate tokio;
+# use atmosphere::prelude::*;
+# async fn test() -> std::result::Result<(), Box<dyn std::error::Error>> {
+let database = std::env::var("DATABASE_URL").unwrap();
+let pool = atmosphere::Pool::connect(&database).await?;
+
+sqlx::query("DROP TABLE foo;")
+    .execute(&pool).await?;
+# Ok(())
+# }
+# fn main() {}
+```

--- a/docs/src/getting-started/schema.md
+++ b/docs/src/getting-started/schema.md
@@ -1,0 +1,65 @@
+# Define your Schema
+
+To make use of Atmosphere, you must define your schema in a way that Atmosphere
+can understand it. To do so, you use Rust structs augmented with the [`Schema`]
+derive macro and some metadata which tells it how to map it to SQL.
+
+Here is an example of what such a schema might look like if you are storing
+users and posts in a database.
+
+```rust
+# extern crate atmosphere;
+# extern crate sqlx;
+use atmosphere::prelude::*;
+
+#[derive(Schema)]
+#[table(schema = "public", name = "user")]
+struct User {
+    #[sql(pk)]
+    id: i32,
+    name: String,
+    #[sql(unique)]
+    email: String,
+}
+
+#[derive(Schema)]
+#[table(schema = "public", name = "post")]
+struct Post {
+    #[sql(pk)]
+    id: i32,
+    #[sql(fk -> User, rename = "author_id")]
+    author: i32,
+    #[sql(unique)]
+    title: String,
+}
+# fn main() {
+# }
+```
+
+## Table properties
+
+Every type you annotate like this corresponds to one table in your Postgres
+database. You must set the table and schema name of the entities by setting
+the appropriate keys on the `#[table]` annotation.
+
+```rust
+# extern crate atmosphere;
+# extern crate sqlx;
+# use atmosphere::prelude::*;
+#[derive(Schema)]
+#[table(schema = "public", name = "users")]
+struct User {
+    # #[sql(pk)]
+    # id: i32,
+    // ...
+}
+# fn main() {
+# }
+```
+
+## Column properties
+
+Every struct member corresponds to one row of your backing table. Here you can
+use the `#[sql]` annotation to add metadata.
+
+[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,11 +1,20 @@
 # Atmosphere
 
-Atmosphere is a postgres interaction framework building on top of sqlx. It
-provides a high level of ergonomics while still enabling low level usage of the
-underlying sqlx concepts.
+Atmosphere is a lightweight SQL framework designed for sustainable,
+database-reliant systems. It leverages Rust's powerful type and macro systems
+to derive SQL schemas from your rust struct definitions into an advanced trait
+system.
+
+It works by leveraging the [`sqlx`][] crate and the Rust macro system to allow
+you to work easily with relational-database mapped entities, while still
+enabling low level usage of the underlying `sqlx` concepts. It currently
+only supports the Postgres database.
 
 ### Sections
 
 **[Getting Started](getting-started/index.md)**
 
+**[Traits](traits/index.md)**
+
 [GitHub]: https://github.com/mara-schulke/atmosphere/tree/main
+[`sqlx`]: https://github.com/launchbadge/sqlx

--- a/docs/src/traits/create.md
+++ b/docs/src/traits/create.md
@@ -1,0 +1,38 @@
+# Create
+
+The [`Create`] trait allows you to create new rows in your tables. Here is an example
+of how to create a user, given that you have derived its [`Schema`]:
+
+```rust
+# extern crate atmosphere;
+# extern crate sqlx;
+# extern crate tokio;
+# use atmosphere::prelude::*;
+#[derive(Schema, Debug, PartialEq)]
+#[table(schema = "public", name = "user")]
+struct User {
+    #[sql(pk)]
+    id: i32,
+    name: String,
+    #[sql(unique)]
+    email: String,
+}
+
+# async fn test() -> std::result::Result<(), Box<dyn std::error::Error>> {
+let database = std::env::var("DATABASE_URL").unwrap();
+let pool = atmosphere::Pool::connect(&database).await?;
+
+let mut user = User {
+    id: 0,
+    name: "demo".to_owned(),
+    email: "some@email.com".to_owned(),
+};
+
+user.create(&pool).await?;
+# Ok(())
+# }
+# fn main() {}
+```
+
+[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`Create`]: https://docs.rs/atmosphere/latest/atmosphere/trait.Create.html

--- a/docs/src/traits/delete.md
+++ b/docs/src/traits/delete.md
@@ -1,0 +1,39 @@
+# Delete
+
+The [`Delete`] trait allows you to read entities from rows in your table. Here is
+an example of how to create a user, given that you have derived its [`Schema`]:
+
+```rust
+# extern crate atmosphere;
+# extern crate sqlx;
+# extern crate tokio;
+# use atmosphere::prelude::*;
+#[derive(Schema, Debug, PartialEq)]
+#[table(schema = "public", name = "user")]
+struct User {
+    #[sql(pk)]
+    id: i32,
+    name: String,
+    #[sql(unique)]
+    email: String,
+}
+
+# async fn test() -> std::result::Result<(), Box<dyn std::error::Error>> {
+let database = std::env::var("DATABASE_URL").unwrap();
+let pool = atmosphere::Pool::connect(&database).await?;
+
+// find user by primary key
+let mut user = User::find(&0, &pool).await?.unwrap();
+
+// delete user data
+user.delete(&pool).await?;
+
+// delete by primary key
+User::delete_by(&4, &pool).await?;
+# Ok(())
+# }
+# fn main() {}
+```
+
+[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`Delete`]: https://docs.rs/atmosphere/latest/atmosphere/trait.Delete.html

--- a/docs/src/traits/index.md
+++ b/docs/src/traits/index.md
@@ -1,0 +1,13 @@
+# Traits
+
+Given that you have derived `Schema` for your entities, Atmosphere provides you
+with some traits for simple CRUD operations on your database. These make it
+very straightforward to do simple operations, but keep in mind that you are
+always able to reach down and write raw SQL manually where it makes sense.
+
+Here are the traits that Atmosphere exposes, along with some examples:
+
+* [Create](crate.md)
+* [Read](read.md)
+* [Update](update.md)
+* [Delete](delete.md)

--- a/docs/src/traits/read.md
+++ b/docs/src/traits/read.md
@@ -1,0 +1,40 @@
+# Read
+
+The [`Read`] trait allows you to read entities from rows in your table. Here is
+an example of how to create a user, given that you have derived its [`Schema`]:
+
+```rust
+# extern crate atmosphere;
+# extern crate sqlx;
+# extern crate tokio;
+# use atmosphere::prelude::*;
+#[derive(Schema, Debug, PartialEq)]
+#[table(schema = "public", name = "user")]
+struct User {
+    #[sql(pk)]
+    id: i32,
+    name: String,
+    #[sql(unique)]
+    email: String,
+}
+
+# async fn test() -> std::result::Result<(), Box<dyn std::error::Error>> {
+let database = std::env::var("DATABASE_URL").unwrap();
+let pool = atmosphere::Pool::connect(&database).await?;
+
+// fetch all users
+let users = User::find_all(&pool).await?;
+
+// find user by primary key
+let user = User::find(&0, &pool).await?;
+
+// refresh user data
+# let mut user = user.unwrap();
+user.reload(&pool).await?;
+# Ok(())
+# }
+# fn main() {}
+```
+
+[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`Read`]: https://docs.rs/atmosphere/latest/atmosphere/trait.Read.html

--- a/docs/src/traits/update.md
+++ b/docs/src/traits/update.md
@@ -1,0 +1,38 @@
+# Update
+
+The [`Update`] trait allows you to read entities from rows in your table. Here is
+an example of how to create a user, given that you have derived its [`Schema`]:
+
+```rust
+# extern crate atmosphere;
+# extern crate sqlx;
+# extern crate tokio;
+# use atmosphere::prelude::*;
+#[derive(Schema, Debug, PartialEq)]
+#[table(schema = "public", name = "user")]
+struct User {
+    #[sql(pk)]
+    id: i32,
+    name: String,
+    #[sql(unique)]
+    email: String,
+}
+
+# async fn test() -> std::result::Result<(), Box<dyn std::error::Error>> {
+let database = std::env::var("DATABASE_URL").unwrap();
+let pool = atmosphere::Pool::connect(&database).await?;
+
+// find user by primary key
+let mut user = User::find(&0, &pool).await?.unwrap();
+
+user.email = "joe@example.com".into();
+
+// update user data
+user.update(&pool).await?;
+# Ok(())
+# }
+# fn main() {}
+```
+
+[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`Update`]: https://docs.rs/atmosphere/latest/atmosphere/trait.Update.html


### PR DESCRIPTION
This updates the book with an expanded getting-started guide and overview of the traits.

Notably, I have added [mdbook-keeper](https://github.com/tfpk/mdbook-keeper/) to allow us to text code examples in the book, this means we are able to keep them in sync (no documentation is still better than incorrect documentation!)

## Todo

I think the CI jobs need to be adjusted slightly — currently, we only build the books *after* merge to main. This is not entirely optimal: it would be good to have a separate job/workflow that runs in MRs as well, so that we can make use of the ability to unit test stuff better (you don't want to merge stuff to main to find out there that the example did not compile, after all).

