### PR TITLE
Re-export sqlx in atmosphere-core

### DIFF
--- a/atmosphere-core/src/lib.rs
+++ b/atmosphere-core/src/lib.rs
@@ -53,3 +53,6 @@ pub type Pool = sqlx::PgPool;
 pub use bind::*;
 pub use error::*;
 pub use schema::*;
+
+#[doc(hidden)]
+pub use sqlx;

--- a/atmosphere-macros/src/derive/queries/unique.rs
+++ b/atmosphere-macros/src/derive/queries/unique.rs
@@ -41,9 +41,9 @@ pub fn queries(table: &Table) -> TokenStream {
                     executor: E
                 ) -> ::atmosphere::Result<Option<#ident>>
                 where
-                    E: ::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::sqlx::database::HasArguments<'q>>::Arguments:
-                        ::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send
+                    E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                        ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send
                 {
                     use ::atmosphere::{
                         query::{Query, QueryError},
@@ -55,7 +55,7 @@ pub fn queries(table: &Table) -> TokenStream {
 
                     let query = sql::select_by::<#ident>(COLUMN.clone());
 
-                    ::sqlx::query_as(query.sql())
+                    ::atmosphere::sqlx::query_as(query.sql())
                         .bind(value)
                         .persistent(false)
                         .fetch_optional(executor)
@@ -67,11 +67,11 @@ pub fn queries(table: &Table) -> TokenStream {
                 pub async fn #delete_by_col<'e, E>(
                     value: &#ty,
                     executor: E,
-                ) -> ::atmosphere::Result<<::atmosphere::Driver as ::sqlx::Database>::QueryResult>
+                ) -> ::atmosphere::Result<<::atmosphere::Driver as ::atmosphere::sqlx::Database>::QueryResult>
                 where
-                    E: ::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::sqlx::database::HasArguments<'q>>::Arguments:
-                        ::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send
+                    E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                        ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send
                 {
                     use ::atmosphere::{
                         query::{Query, QueryError},
@@ -83,7 +83,7 @@ pub fn queries(table: &Table) -> TokenStream {
 
                     let query = sql::delete_by::<#ident>(COLUMN.clone());
 
-                    ::sqlx::query(query.sql())
+                    ::atmosphere::sqlx::query(query.sql())
                         .bind(value)
                         .persistent(false)
                         .execute(executor)

--- a/atmosphere-macros/src/derive/relationships.rs
+++ b/atmosphere-macros/src/derive/relationships.rs
@@ -42,9 +42,9 @@ pub fn relationships(table: &Table) -> TokenStream {
                     executor: E,
                 ) -> ::atmosphere::Result<#other>
                 where
-                    E: ::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::sqlx::database::HasArguments<'q>>::Arguments:
-                        ::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
+                    E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                        ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
                     <#ident as ::atmosphere::rel::RefersTo<#other>>::resolve(&self, executor).await
                 }
 
@@ -54,9 +54,9 @@ pub fn relationships(table: &Table) -> TokenStream {
                     // TODO: either Vec<Self>, or if marked as unique, only Self
                 ) -> ::atmosphere::Result<Vec<#ident>>
                 where
-                    E: ::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::sqlx::database::HasArguments<'q>>::Arguments:
-                        ::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
+                    E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                        ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
                     <#other as ::atmosphere::rel::ReferredBy<#ident>>::resolve_by(pk, executor).await
                 }
             }
@@ -68,20 +68,20 @@ pub fn relationships(table: &Table) -> TokenStream {
                     executor: E,
                 ) -> ::atmosphere::Result<Vec<#ident>>
                 where
-                    E: ::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::sqlx::database::HasArguments<'q>>::Arguments:
-                        ::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
+                    E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                        ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
                     <#other as ::atmosphere::rel::ReferredBy<#ident>>::resolve(&self, executor).await
                 }
 
                 pub async fn #delete_self<'e, E>(
                     &self,
                     executor: E,
-                ) -> ::atmosphere::Result<<::atmosphere::Driver as ::sqlx::Database>::QueryResult>
+                ) -> ::atmosphere::Result<<::atmosphere::Driver as ::atmosphere::sqlx::Database>::QueryResult>
                 where
-                    E: ::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::sqlx::database::HasArguments<'q>>::Arguments:
-                        ::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
+                    E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                        ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
                     <#other as ::atmosphere::rel::ReferredBy<#ident>>::delete_all(&self, executor).await
                 }
             }

--- a/atmosphere-macros/src/lib.rs
+++ b/atmosphere-macros/src/lib.rs
@@ -109,7 +109,7 @@ pub fn table(_: TokenStream, input: TokenStream) -> TokenStream {
     let model = model.to_token_stream();
 
     quote! {
-        #[derive(::atmosphere::prelude::sqlx::FromRow)]
+        #[derive(::atmosphere::sqlx::FromRow)]
         #model
     }
     .into()


### PR DESCRIPTION
This addresses something that I noticed while writing some more documentation in the book:

- When you use `atmosphere::Schema`, it generates code, some of which calls into `::sqlx` (aka the sqlx crate).
- This means that as a user of `atmosphere`, you always need to add `sqlx` to your list of dependencies — even if you never (directly) interact with it (there is a "hidden dependency" because the derive macro generated code depends on it being in the global namespace).
- If you, as an end user, do not directly have `sqlx` as a dependency, you'll get a compile error.

What I do here is I re-export `sqlx` from `atmosphere_core`, and then in the derive macro output I include it as `::atmosphere::sqlx`. Why do I do that? 

- As an end-user, you likely only have `atmosphere` as a direct dependency in your crate.

## Todo

Atmosphere already exports `sqlx` in the `atmosphere::prelude::sqlx`, but I was not sure if it made sense to use that (because it is there for convenience), so I added a re-export at `atmosphere::sqlx` but marked it as `doc(hidden)` so it does not show up (it is an internal implementation detail). Maybe this is not optimal.