### PR TITLE
Enables doctests for macros crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["sqlx", "postgres", "database", "orm", "backend"]
 [workspace.dependencies]
 atmosphere-core = { version = "=0.1.1", path = "atmosphere-core" }
 atmosphere-macros = { version = "=0.1.1", path = "atmosphere-macros" }
+atmosphere = { version = "=0.1.1", path = "." }
 async-trait = "0.1"
 lazy_static = "1"
 sqlx = { version = "0.7", features = ["chrono"] }

--- a/atmosphere-macros/Cargo.toml
+++ b/atmosphere-macros/Cargo.toml
@@ -17,3 +17,7 @@ proc-macro2 = { version = "1.0.36", default-features = false }
 syn = { version = "2.0.39", default-features = false, features = ["parsing", "proc-macro"] }
 quote = { version = "1.0.14", default-features = false }
 lazy_static = "1.4.0"
+
+[dev-dependencies]
+chrono = "0.4.31"
+atmosphere.workspace = true

--- a/atmosphere-macros/src/lib.rs
+++ b/atmosphere-macros/src/lib.rs
@@ -23,7 +23,11 @@ use schema::table::Table;
 /// custom attributes and derives necessary traits and implementations for interacting with the
 /// database.
 ///
-/// Attributes:
+/// Entity attributes:
+///
+/// - `#[table(schema = "schema_name", name = "table_name")]` - Set schema and table name
+///
+/// Field attributes:
 ///
 /// - `#[sql(pk)]` - Mark a column as primary key
 /// - `#[sql(fk -> OtherModel)]` - Mark a column as foreign key on `OtherModel`
@@ -33,18 +37,19 @@ use schema::table::Table;
 ///
 /// Usage:
 ///
-/// ```ignore
+/// ```
+/// # use atmosphere::prelude::*;
 /// #[derive(Schema)]
+/// #[table(schema = "public", name = "user")]
 /// struct User {
 ///     #[sql(pk)]
 ///     id: i32,
 ///     #[sql(unique)]
 ///     username: String,
-///     #[sql(timestamp = create)]
-///     created_at: chrono::DateTime<chrono::Utc>
 /// }
 ///
 /// #[derive(Schema)]
+/// #[table(schema = "public", name = "post")]
 /// struct Post {
 ///     #[sql(pk)]
 ///     id: i32,
@@ -61,10 +66,23 @@ pub fn schema(input: TokenStream) -> TokenStream {
 /// An attribute macro that stores metadata about the sql table.
 /// Must be used after `#[derive(Schema)]`.
 ///
+/// Keys:
+///
+/// - `schema` - sets schema name.
+/// - `name` - sets table name.
+///
 /// Usage:
 ///
-/// ```ignore
-/// #[table(schema = "public", name = "your_table_name")]
+/// ```
+/// # use atmosphere::prelude::*;
+/// # #[derive(Schema)]
+/// #[table(schema = "public", name = "user")]
+/// # struct User {
+/// #     #[sql(pk)]
+/// #     id: i32,
+/// #     #[sql(unique)]
+/// #     username: String,
+/// # }
 /// ```
 #[proc_macro_attribute]
 pub fn table(_: TokenStream, input: TokenStream) -> TokenStream {
@@ -117,11 +135,30 @@ pub fn table(_: TokenStream, input: TokenStream) -> TokenStream {
 
 /// An attribute macro for registering on a table. Must be used after `#[derive(Schema)]`.
 ///
+/// Takes as argument a type which implements `Hook<Self>` for the entity type.
+///
 /// Usage:
 ///
-/// ```ignore
-/// #[hooks(path::to::my::Hook)]
-/// struct MyTable { .. }
+/// ```
+/// # use atmosphere::prelude::*;
+/// # use atmosphere::hooks::*;
+/// #[derive(Schema)]
+/// #[table(schema = "public", name = "user")]
+/// #[hooks(MyHook)]
+/// struct User {
+///     #[sql(pk)]
+///     id: i32,
+///     #[sql(unique)]
+///     username: String,
+/// }
+///
+/// struct MyHook;
+///
+/// impl Hook<User> for MyHook {
+///     fn stage(&self) -> HookStage {
+///         todo!()
+///     }
+/// }
 /// ```
 #[proc_macro_attribute]
 pub fn hooks(attr: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
I noticed in the rustdoc that some code examples are not tested, so I added this to enable doctests for the `atmosphere-macros` crate.